### PR TITLE
merge multiplication counter test

### DIFF
--- a/spec/scripts/string_spec.rb
+++ b/spec/scripts/string_spec.rb
@@ -8,6 +8,18 @@ describe "string_multiplication.rb" do
           "Expected 'string_multiplication.rb' to NOT print the String literal 'HoHoHo', but did."
       end
     end
+
+    multiplication_counter = 0
+    File.foreach(multiplication_file).with_index do |line, line_num|
+      if line.include?("*") 
+        unless line.include?("#")
+          multiplication_counter += 1
+        end
+      end
+    end
+    expect(multiplication_counter).to be >= 1,
+      "Expected 'string_addition.rb' to use the * multiplication method, but only #{multiplication_counter} '*' found."
+
     output = with_captured_stdout { require_relative('../../string_multiplication')} 
     output = "empty" if output.empty? 
     expect(output.match?(/HoHoHo/)).to be(true), "Expected output to be 'HoHoHo', but was #{output}"

--- a/spec/scripts/string_spec.rb
+++ b/spec/scripts/string_spec.rb
@@ -18,7 +18,7 @@ describe "string_multiplication.rb" do
       end
     end
     expect(multiplication_counter).to be >= 1,
-      "Expected 'string_addition.rb' to use the * multiplication method, but only #{multiplication_counter} '*' found."
+      "Expected 'string_addition.rb' to use the * multiplication method, but #{multiplication_counter} '*' found."
 
     output = with_captured_stdout { require_relative('../../string_multiplication')} 
     output = "empty" if output.empty? 


### PR DESCRIPTION
This is my first attempt at a merge into the course material, and my first time requesting code review. So bear with me.

## Problem

I wanted to patch the `string_multiplication.rb` test to prevent it from passing with the code

```
p "Ho" + "Ho" + "Ho"
```

## Solution

I made a counter, looped through the file, and searched for the presence of `*`, with the condition that it doesn't occur on a commented line. So as long as there is one `*` in their code somewhere, it passes. 

## Why I request review

I'm not sure if my solution is good and logical, or if it could be improved. Also, there are still other ways I could imagine cheating the test like:

```
variable = 5 * 6
p "Ho" + "Ho" + "Ho"
```

but I'm not sure we need to worry about every single edge case.